### PR TITLE
Fix NullPointerException when charts is missing

### DIFF
--- a/src/main/kotlin/nl/nielsvanhove/githistoricalstats/project/ProjectConfigReader.kt
+++ b/src/main/kotlin/nl/nielsvanhove/githistoricalstats/project/ProjectConfigReader.kt
@@ -77,7 +77,8 @@ object ProjectConfigReader {
         }
 
         val charts = mutableListOf<Chart>()
-        for (jsonElement in rootObject["charts"]!!.jsonArray) {
+        val chartsArray = rootObject["charts"]?.jsonArray ?: emptyList()
+        for (jsonElement in chartsArray) {
             val item = jsonElement.jsonObject
 
             val chartStacks = mutableListOf<ChartStack>()


### PR DESCRIPTION
If you don't have any charts in your config, the script crashes with a NPE.
This change should fix that. 
(I didn't test this yet, because I'm not sure how to build the script from the project, but it should work)

Example config that gives NPE: 
```
{
  "repo": "~/gitHistoricalStats/repos/action-app-android",
  "branch": "develop",
  "filetypes": [
    "kt"
  ]
}
```